### PR TITLE
fix: make Button component props readonly

### DIFF
--- a/src/app/components/ui/Button.tsx
+++ b/src/app/components/ui/Button.tsx
@@ -3,8 +3,8 @@
 import { ButtonHTMLAttributes } from 'react'
 
 interface ButtonProps extends Readonly<ButtonHTMLAttributes<HTMLButtonElement>> {
-  variant?: 'primary' | 'secondary' | 'outline'
-  size?: 'sm' | 'md' | 'lg'
+  readonly variant?: 'primary' | 'secondary' | 'outline'
+  readonly size?: 'sm' | 'md' | 'lg'
 }
 
 export function Button({ 
@@ -19,12 +19,12 @@ export function Button({
       className={`
         inline-flex items-center justify-center rounded-md font-medium transition-colors
         focus:outline-none focus:ring-2 focus:ring-offset-2
-        [&.primary]:bg-yellow-400 [&.primary]:text-black [&.primary]:hover:bg-yellow-500 [&.primary]:focus:ring-yellow-400
-        [&.secondary]:bg-gray-800 [&.secondary]:text-white [&.secondary]:hover:bg-gray-900 [&.secondary]:focus:ring-gray-800
-        [&.outline]:border-2 [&.outline]:border-gray-800 [&.outline]:text-gray-800 [&.outline]:hover:bg-gray-100 [&.outline]:focus:ring-gray-800
-        [&.sm]:px-3 [&.sm]:py-1.5 [&.sm]:text-sm
-        [&.md]:px-4 [&.md]:py-2 [&.md]:text-base
-        [&.lg]:px-6 [&.lg]:py-3 [&.lg]:text-lg
+        ${variant === 'primary' ? 'bg-yellow-400 text-black hover:bg-yellow-500 focus:ring-yellow-400' : ''}
+        ${variant === 'secondary' ? 'bg-gray-800 text-white hover:bg-gray-900 focus:ring-gray-800' : ''}
+        ${variant === 'outline' ? 'border-2 border-gray-800 text-gray-800 hover:bg-gray-100 focus:ring-gray-800' : ''}
+        ${size === 'sm' ? 'px-3 py-1.5 text-sm' : ''}
+        ${size === 'md' ? 'px-4 py-2 text-base' : ''}
+        ${size === 'lg' ? 'px-6 py-3 text-lg' : ''}
         ${className || ''}
       `}
       {...props}


### PR DESCRIPTION
# 📥 Pull Request - sport-app-landing

## ✅ Description de la tâche

Fix du composant Button : les props sont redonly

---

## 🔧 Modifications apportées

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Refactorisation
- [ ] Autre (préciser ci-dessous)

**Détails :**
- Add readonly modifier to variant and size props
- Fix TypeScript linter warning about read-only props

